### PR TITLE
Increase hour height to improve readability of text in 30min bookings

### DIFF
--- a/src/components/calendar-view/styles.scss
+++ b/src/components/calendar-view/styles.scss
@@ -10,7 +10,7 @@
   border-top: 1px solid $border-colour;
   color: $secondary-text-colour;
   font-size: 16px;
-  height: 2.55em;
+  height: 3.3em;
   line-height: .1;
   margin-left: 3em;
   text-indent: -3em;

--- a/src/components/calendar-view/styles.scss
+++ b/src/components/calendar-view/styles.scss
@@ -23,7 +23,7 @@
   color: $white;
   font-size: 16px;
   left: 20%;
-  padding: 4px;
+  padding: 4px 5px;
   position: absolute;
   width: 80%;
 


### PR DESCRIPTION
A lot of people are making small 30 min bookings and the text in these blocks is chopped off a bit at the bottom. Suggesting increasing the overall height to improve readability / neaten up a bit.

*Before*
![before image](http://i.imgur.com/T33mPSW.png)


*After*
![after image](http://i.imgur.com/pCZCnLM.png)

15 minute meetings would still look terrible however, not sure how to resolve that (if anyone ever books one).

Feedback pls,
Ta! :)